### PR TITLE
add-automatic-updating#1

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,9 +1,9 @@
 $(function() {
-  function buildHTML(message) {
+  var buildMessageHTML = function(message) {
 
-    message_image = message.image == null ? "" : `<img class="lower-message__image" src="${message.image}">`;
-
-    var html = `<div class="message">
+    message_image = message.image == null ? `` : `<img class="lower-message__image" src="${message.image}">`;
+      //data-idが反映されるようにしている
+    var html = `<div class="message" data-id='${message.id}'>
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                       ${message.user_name}
@@ -16,18 +16,20 @@ $(function() {
                     <p class="lower-message__content">
                       ${message.body}
                     </p>
+                    ${message_image}
                   </div>
-                  ${message_image}
                 </div>`
-                
     return html;
-
   }
+
+  function scroll() {
+    $(".messages").animate({scrollTop: $(".messages")[0].scrollHeight});
+  }
+
   $("#new_message").on("submit", function(e) {
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr("action");
-
     $.ajax({
       url: url,
       type: "POST",
@@ -37,16 +39,40 @@ $(function() {
       contentType: false
     })
     .done(function(data){
-      var html = buildHTML(data);
+      var html = buildMessageHTML(data);
       $(".messages").append(html);
-      $(".messages").animate({scrollTop: $(".messages")[0].scrollHeight});
+      scroll();
       $("form")[0].reset();
     })
     .fail(function(data){
       alert("メッセージを入力してください");
     })
     .always(function(data){
-      $(".new_message__submit").prop("disabled", false);
+        $(".new_message__submit").prop("disabled", false);
     })
   })
+
+  $(function() {
+    setInterval(reloadMessages, 5000);
+  });
+
+  var reloadMessages = function() {
+    var last_message_id = $(".message:last").data("id") || 0;
+    $.ajax({
+      url: "api/messages",
+      type: "GET",
+      dataType: "json",
+      data: {id: last_message_id}
+    })
+    .done(function(data) {
+      data.forEach(function(message) {
+        var insertHTML = buildMessageHTML(message);
+        $(".messages").append(insertHTML);
+        scroll();
+      })
+    })
+    .fail(function(jqXHR, textStatus, errorThrown) {
+      console.log("失敗");
+    });
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.body       message.body
+  json.image      message.image.url
+  json.created_at message.created_at.strftime("%Y/%m/%d/(%a) %H:%M")
+  json.user_name  message.user.name
+  json.id         message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {id: "#{message.id}"}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,4 @@
+json.(@message, :body, :image)
 json.id         @message.id
 json.body       @message.body
 json.image      @message.image.url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
   resources :users,  only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: "json" }
+    end
   end
 end


### PR DESCRIPTION
# What
メッセージ送信時の自動更新機能を実装する。

# Why
自動更新を行うことによりチャット時、各ユーザーのビューにてリアルタイムで
メッセージ(画像含む)が確認できるようにする。
↓実際の動作(メッセージ送信時の自動更新)
[![Image from Gyazo](https://i.gyazo.com/d24084a49b0d95bcac17697cf7bc7553.gif)](https://gyazo.com/d24084a49b0d95bcac17697cf7bc7553)